### PR TITLE
feat(syntax-highlighting): add XML syntax Highlighting for XSLT stylesheet

### DIFF
--- a/src/main/resources/schemas/urn:jsonschema:io:gravitee:policy:xslt:configuration:XSLTTransformationPolicyConfiguration.json
+++ b/src/main/resources/schemas/urn:jsonschema:io:gravitee:policy:xslt:configuration:XSLTTransformationPolicyConfiguration.json
@@ -6,8 +6,14 @@
       "title": "XSLT stylesheet",
       "type" : "string",
       "x-schema-form": {
-        "type": "textarea",
-        "placeholder": "Place your XSLT stylesheet here"
+        "type": "codemirror",
+        "codemirrorOptions": {
+          "value": "Place your XSLT stylesheet here",
+  		    "lineWrapping": true,
+  		    "lineNumbers": true,
+  		    "allowDropFileTypes": true,
+  		    "mode": "xml"
+		    }	
       }
     },
     "parameters" : {


### PR DESCRIPTION
…heet textarea

This feature add a XML syntax Highlighting to XSLT stylesheet textarea thank to angular-schema-form-codemirror

See https://github.com/gravitee-io/gravitee-management-webui/pull/183
